### PR TITLE
docs(readme): use cargo install --git --tag (crates.io has only 0.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,38 @@ Intel Mac users: run the Apple Silicon binary through Rosetta, or use
 
 ### Via cargo (any platform with a Rust toolchain)
 
+Install pinned to a release tag, straight from this repo:
+
 ```bash
-cargo install provcheck-cli         # verifier
-cargo install --path crates/provcheck-kit   # signing kit (from source clone)
+cargo install --locked --git https://github.com/CreativeMayhemLtd/provcheck \
+    --tag v0.5.3 provcheck-cli              # verifier
+cargo install --locked --git https://github.com/CreativeMayhemLtd/provcheck \
+    --tag v0.5.3 provcheck-kit              # signing kit
+```
+
+`--locked` enforces the upstream `Cargo.lock` for reproducible builds.
+Bump the `--tag` to whatever shows in [Releases](https://github.com/CreativeMayhemLtd/provcheck/releases).
+
+> **Why not `cargo install provcheck-cli` from crates.io?**
+> Only `provcheck-cli` is currently published on crates.io, and it's
+> frozen at `0.1.1` (many minor versions behind). `provcheck-kit`,
+> `provcheck`, `provcheck-sign`, and `provcheck-publish` are not on
+> crates.io at all. Until the full workspace is published, the
+> `--git --tag` form above is the only way to get current code from
+> cargo.
+
+If you've already cloned the repo, the path-based form also works:
+
+```bash
+cargo install --locked --path crates/provcheck-cli
+cargo install --locked --path crates/provcheck-kit
+```
+
+On Debian/Ubuntu the cargo install also needs these system packages:
+
+```bash
+apt-get install -y pkg-config libssl-dev libpcsclite-dev libdbus-1-dev
+# runtime: libpcsclite1 (provcheck-sign links libpcsclite unconditionally)
 ```
 
 ### In a Docker container (e.g. for a render pipeline)


### PR DESCRIPTION
## Summary

The README's `### Via cargo` block currently recommends:

```bash
cargo install provcheck-cli         # verifier
cargo install --path crates/provcheck-kit   # signing kit (from source clone)
```

The first line is a silent footgun. As of 2026-06-24:

| Crate | crates.io status |
|---|---|
| `provcheck-cli` | published, **frozen at 0.1.1** (many minor versions stale) |
| `provcheck-kit` | **not on crates.io** |
| `provcheck` | **not on crates.io** |
| `provcheck-sign` | **not on crates.io** |
| `provcheck-publish` | **not on crates.io** |

So `cargo install provcheck-cli` succeeds and prints `Installed package provcheck-cli v0.1.1`, leaving the user on code from before the silentcipher detector, the kit, the GUI, the watermark embed path, the Yubikey backend, and the AAC priming fix. Following the README literally puts users five+ minor versions behind, with no warning.

The `--path crates/provcheck-kit` form requires a prior clone, which the surrounding "Via cargo (any platform with a Rust toolchain)" framing doesn't suggest you need.

## Fix

Replace both lines with the `cargo install --locked --git ... --tag vX.Y.Z` form, which:

- works without a clone (the primary use-case for "Via cargo"),
- pins to a release tag (matches what the binary distribution does),
- enforces the upstream `Cargo.lock` (`--locked`) for reproducible builds.

Keep the `--path` form as a clearly-secondary option for users who've already cloned. Add a short explainer call-out on the crates.io situation so future maintainers / users know why the form looks unusual.

While editing the section, also list the Debian/Ubuntu apt packages cargo needs (`pkg-config libssl-dev libpcsclite-dev libdbus-1-dev` build, `libpcsclite1` runtime) — first-time cargo builds otherwise fail on `openssl-sys` (no `libssl-dev`) or link-fail on `provcheck-sign` (no `libpcsclite-dev`).

## Followup

Revert this PR once the full workspace is published to crates.io and `cargo install provcheck-cli` / `cargo install provcheck-kit` give current code.

## Context

Found during a Doomscroll render-host migration from a baked v0.3.3 binary tarball to cargo-install v0.5.3. The `--git --tag` form is what unblocked us; this PR documents it upstream so the next host (and the next user) doesn't hit the same footgun.

## Test plan
- [ ] Render the README on github.com and check the `Install` section formatting (table, code blocks, blockquote, link).
- [ ] On a fresh Debian/Ubuntu container, run the documented apt-get + `cargo install --locked --git ... --tag v0.5.3 provcheck-cli` and confirm a `provcheck --version` of `0.5.3`.
- [ ] Same with `provcheck-kit`.