### PR TITLE
docs(readme): document build + runtime system dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,69 @@ RUN curl -L -o /tmp/kit.tar.gz \
  && rm /tmp/kit.tar.gz
 ```
 
+### Build dependencies
+
+The pre-built release tarballs are self-contained except for one
+runtime shared library — `libpcsclite1` — that the YubiKey support in
+`provcheck-sign` links unconditionally even if you never plug in a
+YubiKey. Without it the binary segfaults at start on a minimal Linux
+image.
+
+If you `cargo install` from source instead, you'll also need a small
+set of build-time packages. The Linux lists below assume Debian /
+Ubuntu (apt) and Fedora / RHEL (dnf); other distros have equivalent
+packages.
+
+**Build-time (Debian/Ubuntu):**
+
+```bash
+apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    libpcsclite-dev \
+    libdbus-1-dev \
+    ca-certificates git
+```
+
+**Build-time (Fedora/RHEL):**
+
+```bash
+dnf install -y \
+    pkgconf-pkg-config \
+    openssl-devel \
+    pcsc-lite-devel \
+    dbus-devel \
+    ca-certificates git
+```
+
+**Runtime (any Linux):**
+
+```bash
+# Debian/Ubuntu
+apt-get install -y libpcsclite1
+# Fedora/RHEL
+dnf install -y pcsc-lite-libs
+```
+
+Why each:
+
+| Package | Pulled in by | Used for |
+|---|---|---|
+| `pkg-config` | several `*-sys` crates | resolving native dep flags |
+| `libssl-dev` | `openssl-sys 0.9.117` (transitive — `provcheck-sign`) | OpenSSL link. `c2pa` core uses `rust_native_crypto`, but `provcheck-sign` still pulls `openssl-sys` transitively; without `libssl-dev` cargo fails at `pkg-config --libs --cflags openssl`. |
+| `libpcsclite-dev` (build) / `libpcsclite1` (runtime) | `yubikey` crate via `provcheck-sign` | PC/SC smartcard interface for the YubiKey PIV backend. Linked unconditionally — even users who never touch a YubiKey need the runtime lib or the binary segfaults at start. |
+| `libdbus-1-dev` | `keyring v3` Secret Service backend | OS keyring on Linux (`provcheck-kit init` default backend). |
+| `ca-certificates`, `git` | cargo + HTTPS | only needed for `cargo install --git`. |
+
+macOS and Windows builds don't need the apt list — the equivalent
+libraries ship in the OS (Keychain, PC/SC) or are vendored.
+
+> **Future improvement (not done in this PR):** feature-gate
+> `provcheck-sign`'s `openssl-sys` dependency so the workspace
+> consistently uses `rust_native_crypto` / `rustls`. That would let us
+> drop `libssl-dev` and the corresponding OpenSSL CVE-tracking burden
+> from the deployment surface.
+
 ## Try it
 
 Two example signed files ship with the repo plus two unsigned controls:


### PR DESCRIPTION
## Summary

The README's Install section covers pre-built binaries, `cargo install`, and a Dockerfile example, but doesn't document the native system packages either path needs on Linux. Both fail in non-obvious ways without them:

- **Pre-built binary on a minimal Linux image:** segfaults at start because `provcheck-sign` links `libpcsclite` unconditionally (YubiKey backend support) even when no YubiKey is present.
- **`cargo install` on a fresh Debian image:** fails compiling `openssl-sys 0.9.117` with `Package openssl was not found by pkg-config` — `provcheck-sign` pulls `openssl-sys` transitively even though `c2pa` core uses `rust_native_crypto`.
- **`cargo install` after the openssl-sys fix:** fails again on the `keyring v3` Secret Service backend without `libdbus-1-dev`.

Each was discovered the hard way while migrating a Doomscroll render host from a baked v0.3.3 binary tarball to cargo-install v0.5.3 on 2026-06-24.

## What this PR adds

A new `### Build dependencies` subsection under `## Install` with:

- **Build-time apt list** (`pkg-config libssl-dev libpcsclite-dev libdbus-1-dev`) and dnf equivalent.
- **Runtime list** (`libpcsclite1` / `pcsc-lite-libs`) so pre-built tarball users on a slim base image don't get the segfault-at-start surprise.
- A **per-package "why" table** that points at the upstream / transitive crate responsible (`openssl-sys 0.9.117` → `libssl-dev`, `yubikey` crate via `provcheck-sign` → `libpcsclite-dev`, etc.).
- A note that macOS and Windows builds don't need the apt list (system frameworks ship the equivalent libraries).

## Followup (not in this PR)

> Feature-gate `provcheck-sign`'s `openssl-sys` dep so the workspace consistently uses `rust_native_crypto` / `rustls`. That would let us drop `libssl-dev` and the corresponding OpenSSL CVE-tracking burden from the deployment surface.

Explicitly NOT included as a code change here — flagged in the README as a future improvement so it's recorded somewhere visible. Happy to file a separate issue if you'd prefer that as the tracking vehicle.

## Test plan
- [ ] Render the README on github.com and check that the new subsection renders cleanly (tables, code blocks, the blockquote at the bottom).
- [ ] Follow the documented apt-get on a fresh `debian:bookworm-slim` container and `cargo install --locked --git ... --tag v0.5.3 provcheck-kit` succeeds end-to-end.
- [ ] Strip `libpcsclite1` from a tarball-install image and confirm the segfault reproduces; reinstall and confirm it goes away.